### PR TITLE
feat(debug): created a basic perfoverlay (heap usage+fps)

### DIFF
--- a/src/core/debug/perf_monitor.cpp
+++ b/src/core/debug/perf_monitor.cpp
@@ -1,0 +1,33 @@
+#include "perf_monitor.hh"
+#include "../../render/renderer.hh"
+#include "psyqo/alloc.h"
+
+GameplayHUD PerfMonitor::m_perfMontiorHUD = GameplayHUD("Perf Monitor", {.pos = {5, 10}, .size = {100, 100}});
+TextHUDElement *PerfMonitor::m_heapSizeText = nullptr;
+TextHUDElement *PerfMonitor::m_fpsText = nullptr;
+bool PerfMonitor::m_hasInitialized = false;
+
+void PerfMonitor::Init(void) {
+  m_heapSizeText = m_perfMontiorHUD.AddTextHUDElement(TextHUDElement("HEAP", {.pos = {5, 0}, .size = {100, 100}}));
+  m_heapSizeText->SetFont(Renderer::Instance().SystemFont());
+
+  m_fpsText = m_perfMontiorHUD.AddTextHUDElement(TextHUDElement("FPS", {.pos = {5, 15}, .size = {100, 100}}));
+  m_fpsText->SetFont(Renderer::Instance().SystemFont());
+  m_hasInitialized = true;
+}
+
+void PerfMonitor::Render(uint32_t deltaTime) {
+  if (!m_hasInitialized)
+    Init();
+
+  char heapSize[GAMEPLAY_HUD_ELEMENT_MAX_STR_LEN];
+  snprintf(heapSize, GAMEPLAY_HUD_ELEMENT_MAX_STR_LEN, "Heap Used: %d",
+           (int)((uint8_t *)psyqo_heap_end() - (uint8_t *)psyqo_heap_start()));
+  m_heapSizeText->SetDisplayText(heapSize);
+
+  char fps[GAMEPLAY_HUD_ELEMENT_MAX_STR_LEN];
+  snprintf(fps, GAMEPLAY_HUD_ELEMENT_MAX_STR_LEN, "FPS: %d", Renderer::Instance().GPU().getRefreshRate() / deltaTime);
+  m_fpsText->SetDisplayText(fps);
+
+  m_perfMontiorHUD.Render();
+}

--- a/src/core/debug/perf_monitor.hh
+++ b/src/core/debug/perf_monitor.hh
@@ -1,0 +1,20 @@
+#ifndef _PERF_MONITOR_H
+#define _PERF_MONITOR_H
+
+#include "../../ui/hud/gameplay_hud.hh"
+
+class PerfMonitor final {
+public:
+  // this should be called last in your render loop
+  static void Render(uint32_t deltaTime);
+
+private:
+  static bool m_hasInitialized;
+  static GameplayHUD m_perfMontiorHUD;
+  static TextHUDElement *m_heapSizeText;
+  static TextHUDElement *m_fpsText;
+
+  static void Init(void);
+};
+
+#endif

--- a/src/scenes/gameplay.cpp
+++ b/src/scenes/gameplay.cpp
@@ -1,5 +1,6 @@
 #include "gameplay.hh"
 #include "../core/collision.hh"
+#include "../core/debug//perf_monitor.hh"
 #include "../core/debug/debug_menu.hh"
 #include "../core/object/gameobject_manager.hh"
 #include "../core/raycast.hh"
@@ -64,16 +65,6 @@ void GameplayScene::frame() {
   if (DebugMenu::IsEnabled())
     return;
 
-  if (DebugMenu::DisplayDebugHUD()) {
-    char heapSize[GAMEPLAY_HUD_ELEMENT_MAX_STR_LEN];
-    snprintf(heapSize, GAMEPLAY_HUD_ELEMENT_MAX_STR_LEN, "Heap Used: %d",
-             (int)((uint8_t *)psyqo_heap_end() - (uint8_t *)psyqo_heap_start()));
-    m_heapSizeText->SetDisplayText(heapSize);
-
-    char fps[GAMEPLAY_HUD_ELEMENT_MAX_STR_LEN];
-    snprintf(fps, GAMEPLAY_HUD_ELEMENT_MAX_STR_LEN, "FPS: %d", renderInstance.GPU().getRefreshRate() / deltaTime);
-    m_fpsText->SetDisplayText(fps);
-
-    m_debugHUD.Render();
-  }
+  if (DebugMenu::DisplayDebugHUD())
+    PerfMonitor::Render(deltaTime);
 }


### PR DESCRIPTION
Added a performance overlay which is available by calling `PerfMonitor::Render(deltaTime)` last in your scene's render loop. It will display current heap usage and FPS in the top left corner.