### PR TITLE
feat: pcdrv + archive support

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,10 +14,10 @@ I wanted to open-source this now as there is zero advantage for both myself or M
 
 This engine is just a library that links into your game code and so you will need to create a new Git repository with the engine as a submodule, along with the nugget submodule that is inside of that.
 
-### CD-ROM
-If you wish to make your game run from an ISO and make use of the PS1 CD-ROM drive, then you will also need to make sure you have [mkpsxiso](https://github.com/Lameguy64/mkpsxiso).
+### Asset Usage
+If you wish to dynamically load assets rather than having them hardcoded as header files or whatever then you will need to take a look at pcsx-redux's [authoring tool](https://github.com/grumpycoders/pcsx-redux/tree/main/tools/authoring). 
 
-In the `cdrom` directory you will see an example of an XML file that mkpsxiso can use. `iso.xml` and `system.cnf` have already been setup in such a way that they should be plug and play.
+In the `cdrom` directory you will see an example [toc.json](./cdrom/toc.json) that you can pass into the authoring tool to generate your ISO.
 
 ### Creating your game
 

--- a/cdrom/toc.json
+++ b/cdrom/toc.json
@@ -1,0 +1,20 @@
+{
+    "executable": "../../build/ssweep.ps-exe",
+    "pvd": {
+        "system_id": "PLAYSTATION",
+        "volume_id": "MADNIGHT_ENGINE",
+        "volume_set_id": "MADNIGHT_ENGINE",
+        "publisher": "MADNIGHT GAMES",
+        "preparer": "MADNIGHT GAMES",
+        "application_id": "SLUS-9999",
+        "copyright": "COPYRIGHT MADNIGHT GAMES 2025-2026",
+        "abstract": "MY_ABSTRACT",
+        "bibliographic": "MY_BIBLIOGRAPHIC"
+    },
+
+    "files": [
+        { "path": "assets/cube.meshbin", "name": "MODELS/CUBE.MB" },
+        { "path": "assets/residential_street.meshbin", "name": "MODELS/STREET.MB" },
+        { "path": "assets/residential_street.tim", "name": "TEXTURES/STREET.TIM" }
+    ]
+}

--- a/src/animation/animation_manager.cpp
+++ b/src/animation/animation_manager.cpp
@@ -1,5 +1,5 @@
 #include "animation_manager.hh"
-#include "../helpers/cdrom.hh"
+#include "../helpers/archive.hh"
 #include "EASTL/fixed_string.h"
 #include "animation.hh"
 #include "psyqo/xprintf.h"
@@ -7,7 +7,7 @@
 AnimationBin AnimationManager::m_loadedAnimBin = {0, {}};
 
 psyqo::Coroutine<> AnimationManager::LoadAnimationFromCDRom(const char *animationsFile) {
-  auto buffer = co_await CDRomHelper::LoadFile(animationsFile);
+  auto buffer = co_await ArchiveHelper::LoadFile(animationsFile);
 
   void *data = buffer.data();
   size_t size = buffer.size();

--- a/src/animation/animation_manager.cpp
+++ b/src/animation/animation_manager.cpp
@@ -6,7 +6,7 @@
 
 AnimationBin AnimationManager::m_loadedAnimBin = {0, {}};
 
-psyqo::Coroutine<> AnimationManager::LoadAnimationFromCDRom(const char *animationsFile) {
+psyqo::Coroutine<> AnimationManager::LoadAnimation(const char *animationsFile) {
   auto buffer = co_await ArchiveHelper::LoadFile(animationsFile);
 
   void *data = buffer.data();

--- a/src/animation/animation_manager.hh
+++ b/src/animation/animation_manager.hh
@@ -9,7 +9,7 @@ class AnimationManager final {
   static AnimationBin m_loadedAnimBin;
 
 public:
-  static psyqo::Coroutine<> LoadAnimationFromCDRom(const char *animationsFile);
+  static psyqo::Coroutine<> LoadAnimation(const char *animationsFile);
   static Animation *GetAnimationFromName(const eastl::fixed_string<char, MAX_ANIMATION_NAME_LENGTH> &animationName);
 };
 

--- a/src/helpers/archive.cpp
+++ b/src/helpers/archive.cpp
@@ -1,0 +1,50 @@
+#include "archive.hh"
+#include "cdrom.hh"
+#include "psyqo-paths/archive-manager.hh"
+#include "psyqo/xprintf.h"
+#include "../render/renderer.hh"
+
+#ifdef PCDRV
+psyqo::CDRomPCDrv ArchiveHelper::m_cdrom("ssweep.iso");
+#endif
+psyqo::paths::ArchiveManager ArchiveHelper::m_archiveManager;
+bool ArchiveHelper::m_archiveManagerInit = false;
+char ArchiveHelper::m_loadingFileName[MAX_ARCHIVE_FILE_NAME_LEN];
+
+void ArchiveHelper::init() {
+	m_archiveManager.registerUCL_NRV2EDecompressor();
+
+#ifndef PCDRV
+	auto& cdrom = CDRomHelper::CDRomDevice();
+#else
+	auto cdrom = m_cdrom;
+#endif
+	
+    m_archiveManager.initialize(23, cdrom, [](bool success) {
+		m_archiveManagerInit = success;
+		printf("Archive: Initialize result=%d\n", m_archiveManagerInit);
+	});
+}
+
+psyqo::Coroutine<psyqo::Buffer<uint8_t>> ArchiveHelper::LoadFile(const char *fileName) {
+	if (m_archiveManagerInit) {
+		snprintf(m_loadingFileName, MAX_ARCHIVE_FILE_NAME_LEN, "%s", fileName);
+
+		printf("Archive: Attempting to read %s...\n", m_loadingFileName);
+
+#ifdef PCDRV
+		auto buffer = co_await m_archiveManager.readFile(m_loadingFileName, m_cdrom);
+#else
+		auto buffer = co_await m_archiveManager.readFile(m_loadingFileName, CDRomHelper::CDRomDevice());
+#endif
+		if (buffer.empty())
+			printf("Archive: File %s not found or empty\n", m_loadingFileName);
+		else
+			printf("Archive: Read %d bytes\n", buffer.size());
+		
+		co_return eastl::move(buffer);
+	} else {
+		printf("Archive: Manager not initialized.\n");
+		co_return psyqo::Buffer<uint8_t>{};
+	}
+}

--- a/src/helpers/archive.cpp
+++ b/src/helpers/archive.cpp
@@ -11,7 +11,7 @@ psyqo::paths::ArchiveManager ArchiveHelper::m_archiveManager;
 bool ArchiveHelper::m_archiveManagerInit = false;
 char ArchiveHelper::m_loadingFileName[MAX_ARCHIVE_FILE_NAME_LEN];
 
-void ArchiveHelper::init() {
+void ArchiveHelper::init(eastl::function<void()> cb) {
 	m_archiveManager.registerUCL_NRV2EDecompressor();
 
 #ifndef PCDRV
@@ -20,9 +20,10 @@ void ArchiveHelper::init() {
 	auto cdrom = m_cdrom;
 #endif
 	
-    m_archiveManager.initialize(23, cdrom, [](bool success) {
+    m_archiveManager.initialize(23, cdrom, [cb](bool success) {
 		m_archiveManagerInit = success;
 		printf("Archive: Initialize result=%d\n", m_archiveManagerInit);
+		cb();
 	});
 }
 

--- a/src/helpers/archive.cpp
+++ b/src/helpers/archive.cpp
@@ -22,30 +22,28 @@ void ArchiveHelper::init(eastl::function<void()> cb) {
 	
     m_archiveManager.initialize(23, cdrom, [cb](bool success) {
 		m_archiveManagerInit = success;
-		printf("Archive: Initialize result=%d\n", m_archiveManagerInit);
+		printf("ARCHIVE: Initialize result=%d\n", m_archiveManagerInit);
 		cb();
 	});
 }
 
 psyqo::Coroutine<psyqo::Buffer<uint8_t>> ArchiveHelper::LoadFile(const char *fileName) {
 	if (m_archiveManagerInit) {
-		snprintf(m_loadingFileName, MAX_ARCHIVE_FILE_NAME_LEN, "%s", fileName);
-
-		printf("Archive: Attempting to read %s...\n", m_loadingFileName);
+		printf("ARCHIVE: Attempting to read %s...\n", fileName);
 
 #ifdef PCDRV
 		auto buffer = co_await m_archiveManager.readFile(m_loadingFileName, m_cdrom);
 #else
-		auto buffer = co_await m_archiveManager.readFile(m_loadingFileName, CDRomHelper::CDRomDevice());
+		auto buffer = co_await m_archiveManager.readFile(fileName, CDRomHelper::CDRomDevice());
 #endif
 		if (buffer.empty())
-			printf("Archive: File %s not found or empty\n", m_loadingFileName);
+			printf("ARCHIVE: File %s not found or empty\n", fileName);
 		else
-			printf("Archive: Read %d bytes\n", buffer.size());
+			printf("ARCHIVE: Read %d bytes\n", buffer.size());
 		
 		co_return eastl::move(buffer);
 	} else {
-		printf("Archive: Manager not initialized.\n");
+		printf("ARCHIVE: Manager not initialized.\n");
 		co_return psyqo::Buffer<uint8_t>{};
 	}
 }

--- a/src/helpers/archive.cpp
+++ b/src/helpers/archive.cpp
@@ -17,7 +17,7 @@ void ArchiveHelper::init(eastl::function<void()> cb) {
 #ifndef PCDRV
 	auto& cdrom = CDRomHelper::CDRomDevice();
 #else
-	auto cdrom = m_cdrom;
+	auto& cdrom = m_cdrom;
 #endif
 	
     m_archiveManager.initialize(23, cdrom, [cb](bool success) {
@@ -31,10 +31,16 @@ psyqo::Coroutine<psyqo::Buffer<uint8_t>> ArchiveHelper::LoadFile(const char *fil
 	if (m_archiveManagerInit) {
 		printf("ARCHIVE: Attempting to read %s...\n", fileName);
 
-#ifdef PCDRV
-		auto buffer = co_await m_archiveManager.readFile(m_loadingFileName, m_cdrom);
+#ifndef PCDRV
+	auto& cdrom = CDRomHelper::CDRomDevice();
 #else
-		auto buffer = co_await m_archiveManager.readFile(fileName, CDRomHelper::CDRomDevice());
+	auto& cdrom = m_cdrom;
+#endif		
+
+#ifdef PCDRV
+		auto buffer = co_await m_archiveManager.readFile(fileName, cdrom);
+#else
+		auto buffer = co_await m_archiveManager.readFile(fileName, cdrom);
 #endif
 		if (buffer.empty())
 			printf("ARCHIVE: File %s not found or empty\n", fileName);

--- a/src/helpers/archive.hh
+++ b/src/helpers/archive.hh
@@ -11,7 +11,7 @@ constexpr uint8_t MAX_ARCHIVE_FILE_NAME_LEN = 255;
 
 class ArchiveHelper final {
 public:
-    static void init();
+    static void init(eastl::function<void()> cb);
     static psyqo::Coroutine<psyqo::Buffer<uint8_t>> LoadFile(const char* fileName);
 private:
 #ifdef PCDRV

--- a/src/helpers/archive.hh
+++ b/src/helpers/archive.hh
@@ -1,0 +1,23 @@
+#pragma once
+
+#include "psyqo/coroutine.hh"
+#include "psyqo/buffer.hh"
+#ifdef PCDRV
+#include "psyqo/cdrom-pcdrv.hh"
+#endif
+#include "psyqo-paths/archive-manager.hh"
+
+constexpr uint8_t MAX_ARCHIVE_FILE_NAME_LEN = 255;
+
+class ArchiveHelper final {
+public:
+    static void init();
+    static psyqo::Coroutine<psyqo::Buffer<uint8_t>> LoadFile(const char* fileName);
+private:
+#ifdef PCDRV
+    static psyqo::CDRomPCDrv m_cdrom;
+#endif
+    static psyqo::paths::ArchiveManager m_archiveManager;
+    static bool m_archiveManagerInit;
+    static char m_loadingFileName[MAX_ARCHIVE_FILE_NAME_LEN];
+};

--- a/src/helpers/cdrom.cpp
+++ b/src/helpers/cdrom.cpp
@@ -1,42 +1,77 @@
+#include "cdrom.hh"
 #include "psyqo/alloc.h"
 #include "psyqo/xprintf.h"
-#include "cdrom.hh"
+
+#ifndef PCDRV
 
 psyqo::CDRomDevice CDRomHelper::m_cdrom;
 psyqo::ISO9660Parser CDRomHelper::m_isoParser = psyqo::ISO9660Parser(&m_cdrom);
 psyqo::paths::CDRomLoader CDRomHelper::m_cdromLoader;
 char CDRomHelper::m_loadingFileName[MAX_CDROM_FILE_NAME_LEN];
 
-void CDRomHelper::init()
-{
-    m_cdrom.prepare();
-    m_cdrom.reset();
+#else
+
+#include "common/kernel/pcdrv.h"
+
+#endif
+
+void CDRomHelper::init() {
+#ifndef PCDRV
+	m_cdrom.prepare();
+	m_cdrom.reset();
+#else
+	PCinit();
+#endif
 }
 
-// reads a file off of the cd rom into memory (most likely a file full of binary data)
-// dont forget to free the returned data when you're done with it
-// allows you to wait for a file to be ready off cdrom without being stuck in callback hell
-psyqo::Coroutine<psyqo::Buffer<uint8_t>> CDRomHelper::LoadFile(const char *fileName)
-{
-    get_iso_file_name(fileName, m_loadingFileName);
-    printf("CD ROM: Attempting to read %s...\n", m_loadingFileName);
+psyqo::Coroutine<psyqo::Buffer<uint8_t>> CDRomHelper::LoadFile(const char *fileName) {
+#ifndef PCDRV
+	get_iso_file_name(fileName, m_loadingFileName);
+	printf("CDRom: Attempting to read %s...\n", m_loadingFileName);
 
-    auto buffer = co_await m_cdromLoader.readFile(m_loadingFileName, m_isoParser);
-    printf("CD ROM: Finished reading file (%d bytes) from cd rom.\n", buffer.size());
+	auto buffer = co_await m_cdromLoader.readFile(m_loadingFileName, m_isoParser);
+	if (buffer.empty())
+		printf("CDRom: File %s not found or empty\n", m_loadingFileName);
+	else
+		printf("CDRom: Read %d bytes\n", buffer.size());
+	
+        co_return eastl::move(buffer);
+#else
+	printf("PCDrv: Attempting to read %s...\n", fileName);
 
-    // the file isnt there or its empty
-    if (buffer.empty())
-    {
-        buffer.clear();
-        printf("CD ROM: File %s not found on CD or file is empty\n", m_loadingFileName);
-    }
+	psyqo::Buffer<uint8_t> buffer;
 
-    // callback to the loader
-    co_return eastl::move(buffer);
+	int fd = PCopen(fileName, 0, 0);
+	if (fd < 0) {
+		printf("PCDrv: Failed to open %s\n", fileName);
+		co_return eastl::move(buffer);
+	}
+
+	int size = PClseek(fd, 0, 2); // SEEK_END
+	if (size <= 0) {
+		printf("PCDrv: Failed to get size of %s\n", fileName);
+		PCclose(fd);
+		co_return eastl::move(buffer);
+	}
+	PClseek(fd, 0, 0); // SEEK_SET
+
+	buffer = psyqo::Buffer<uint8_t>(static_cast<size_t>(size));
+	int bytesRead = PCread(fd, buffer.data(), size);
+	PCclose(fd);
+
+	if (bytesRead != size) {
+		printf("PCDrv: Short read on %s (%d of %d bytes)\n", fileName, bytesRead, size);
+		buffer.clear();
+		co_return eastl::move(buffer);
+	}
+
+	printf("PCDrv: Read %d bytes from %s\n", size, fileName);
+	co_return eastl::move(buffer);
+#endif
 }
 
-void CDRomHelper::get_iso_file_name(const char *file_name, char *iso_filename)
-{
-    // modify the given file name into the correct format for the ps1 to read it
-    snprintf(iso_filename, MAX_CDROM_FILE_NAME_LEN, "%s;1", file_name);
+#ifndef PCDRV
+void CDRomHelper::get_iso_file_name(const char *file_name, char *iso_filename) {
+	snprintf(iso_filename, MAX_CDROM_FILE_NAME_LEN, "%s;1", file_name);
 }
+#endif

--- a/src/helpers/cdrom.cpp
+++ b/src/helpers/cdrom.cpp
@@ -18,7 +18,7 @@ char CDRomHelper::m_loadingFileName[MAX_CDROM_FILE_NAME_LEN];
 
 #endif
 
-void CDRomHelper::init() {
+void CDRomHelper::init(eastl::function<void()> cb) {
 #ifndef PCDRV
 	m_cdrom.prepare();
 	m_cdrom.resetBlocking(Renderer::Instance().GPU());
@@ -26,7 +26,7 @@ void CDRomHelper::init() {
 	PCinit();
 #endif
 
-  ArchiveHelper::init();
+  ArchiveHelper::init(cb);
 }
 
 psyqo::Coroutine<psyqo::Buffer<uint8_t>> CDRomHelper::LoadFile(const char *fileName) {

--- a/src/helpers/cdrom.cpp
+++ b/src/helpers/cdrom.cpp
@@ -1,6 +1,9 @@
 #include "cdrom.hh"
 #include "psyqo/alloc.h"
+#include "psyqo/coroutine.hh"
 #include "psyqo/xprintf.h"
+#include "../render/renderer.hh"
+#include "archive.hh"
 
 #ifndef PCDRV
 
@@ -18,10 +21,12 @@ char CDRomHelper::m_loadingFileName[MAX_CDROM_FILE_NAME_LEN];
 void CDRomHelper::init() {
 #ifndef PCDRV
 	m_cdrom.prepare();
-	m_cdrom.reset();
+	m_cdrom.resetBlocking(Renderer::Instance().GPU());
 #else
 	PCinit();
 #endif
+
+  ArchiveHelper::init();
 }
 
 psyqo::Coroutine<psyqo::Buffer<uint8_t>> CDRomHelper::LoadFile(const char *fileName) {

--- a/src/helpers/cdrom.hh
+++ b/src/helpers/cdrom.hh
@@ -14,14 +14,12 @@
 class CDRomHelper final
 {
 public:
-    static void init();
+    static void init(eastl::function<void()> cb);
     static psyqo::Coroutine<psyqo::Buffer<uint8_t>> LoadFile(const char *fileName);
 
 #ifndef PCDRV
     static psyqo::CDRomDevice& CDRomDevice() { return m_cdrom; }
-#endif
 private:
-#ifndef PCDRV
     static psyqo::CDRomDevice m_cdrom;
     static psyqo::ISO9660Parser m_isoParser;
     static psyqo::paths::CDRomLoader m_cdromLoader;

--- a/src/helpers/cdrom.hh
+++ b/src/helpers/cdrom.hh
@@ -1,23 +1,28 @@
-#ifndef _CDROM_H
-#define _CDROM_H
+#pragma once
 
-#include "psyqo/cdrom-device.hh"
+#include <stdint.h>
 #include "psyqo/coroutine.hh"
+#include "psyqo/buffer.hh"
+
+#ifndef PCDRV
+#include "psyqo/cdrom-device.hh"
 #include "psyqo/iso9660-parser.hh"
 #include "psyqo-paths/cdrom-loader.hh"
 #include "file_defs.hh"
+#endif
 
 class CDRomHelper final
 {
+public:
+    static void init();
+    static psyqo::Coroutine<psyqo::Buffer<uint8_t>> LoadFile(const char *fileName);
+
+private:
+#ifndef PCDRV
     static psyqo::CDRomDevice m_cdrom;
     static psyqo::ISO9660Parser m_isoParser;
     static psyqo::paths::CDRomLoader m_cdromLoader;
     static char m_loadingFileName[MAX_CDROM_FILE_NAME_LEN];
-
-public:
-    static void init();
-    static psyqo::Coroutine<psyqo::Buffer<uint8_t>> LoadFile(const char *fileName);
     static void get_iso_file_name(const char *file_name, char *iso_filename);
-};
-
 #endif
+};

--- a/src/helpers/cdrom.hh
+++ b/src/helpers/cdrom.hh
@@ -17,6 +17,9 @@ public:
     static void init();
     static psyqo::Coroutine<psyqo::Buffer<uint8_t>> LoadFile(const char *fileName);
 
+#ifndef PCDRV
+    static psyqo::CDRomDevice& CDRomDevice() { return m_cdrom; }
+#endif
 private:
 #ifndef PCDRV
     static psyqo::CDRomDevice m_cdrom;

--- a/src/madnight.cpp
+++ b/src/madnight.cpp
@@ -2,6 +2,7 @@
 
 #include "helpers/archive.hh"
 #include "psyqo/scene.hh"
+#include "psyqo/xprintf.h"
 
 #include "core/debug/debug_menu.hh"
 #include "helpers/cdrom.hh"
@@ -25,32 +26,35 @@ static LoadingScene loadingScene;
 void MadnightEngine::prepare() {
   // gpu config comes first, along with initialize.
   // once we call initialize then we can start using the vram etc.
-  psyqo::GPU::Configuration gpu_config;
-  gpu_config.set(psyqo::GPU::Resolution::W320)
+  psyqo::GPU::Configuration gpuConfig;
+  gpuConfig.set(psyqo::GPU::Resolution::W320)
       .set(psyqo::GPU::VideoMode::NTSC)
       .set(psyqo::GPU::ColorMode::C15BITS)
       .set(psyqo::GPU::Interlace::PROGRESSIVE);
-  gpu().initialize(gpu_config);
+  gpu().initialize(gpuConfig);
 
   // gpu inits
   Renderer::Init(gpu());
 
+  // push a scene to display whilst we do hardware inits
+  pushScene(&loadingScene);
+
   // hardware inits
-  CDRomHelper::init();
-  SoundManager::Init();
-  // Unlike the `SimplePad` class, the `AdvancedPad` class doesn't need to be initialized
-  // in the `start` method of the root `Scene` object. It can be initialized here.
-  // PollingMode::Fast is used to reduce input lag, but it will increase CPU usage.
-  // PollingMode::Normal is the default, and will poll one port per frame.
-  m_input.initialize(psyqo::AdvancedPad::PollingMode::Fast);
+  CDRomHelper::init([this]() {
+    SoundManager::Init();
+    // Unlike the `SimplePad` class, the `AdvancedPad` class doesn't need to be initialized
+    // in the `start` method of the root `Scene` object. It can be initialized here.
+    // PollingMode::Fast is used to reduce input lag, but it will increase CPU usage.
+    // PollingMode::Normal is the default, and will poll one port per frame.
+    m_input.initialize(psyqo::AdvancedPad::PollingMode::Fast);
 
-  // our application inits
-  DebugMenu::Init();
-}
+    // our application inits
+    DebugMenu::Init();
 
-void MadnightEngine::createScene() {
-  m_initialLoadRoutine = InitialLoad();
-  m_initialLoadRoutine.resume();
+    // hook into the game code
+    m_initialLoadRoutine = InitialLoad();
+    m_initialLoadRoutine.resume();
+  });
 }
 
 psyqo::Coroutine<> MadnightEngine::InitialLoad(void) { co_await g_madnightEngineGame.InitialLoad(); }

--- a/src/madnight.cpp
+++ b/src/madnight.cpp
@@ -1,5 +1,6 @@
 /* based off the psyqo cube example */
 
+#include "helpers/archive.hh"
 #include "psyqo/scene.hh"
 
 #include "core/debug/debug_menu.hh"
@@ -31,6 +32,9 @@ void MadnightEngine::prepare() {
       .set(psyqo::GPU::Interlace::PROGRESSIVE);
   gpu().initialize(gpu_config);
 
+  // gpu inits
+  Renderer::Init(gpu());
+
   // hardware inits
   CDRomHelper::init();
   SoundManager::Init();
@@ -39,9 +43,6 @@ void MadnightEngine::prepare() {
   // PollingMode::Fast is used to reduce input lag, but it will increase CPU usage.
   // PollingMode::Normal is the default, and will poll one port per frame.
   m_input.initialize(psyqo::AdvancedPad::PollingMode::Fast);
-
-  // gpu inits
-  Renderer::Init(gpu());
 
   // our application inits
   DebugMenu::Init();

--- a/src/madnight.hh
+++ b/src/madnight.hh
@@ -13,7 +13,6 @@
 class MadnightEngine final : public psyqo::Application
 {
     void prepare() override;
-    void createScene() override;
 
     psyqo::Coroutine<> m_initialLoadRoutine;
 public:

--- a/src/madnight.hh
+++ b/src/madnight.hh
@@ -16,7 +16,6 @@ class MadnightEngine final : public psyqo::Application
     void createScene() override;
 
     psyqo::Coroutine<> m_initialLoadRoutine;
-
 public:
     psyqo::Trig<> m_trig;
     psyqo::AdvancedPad m_input;
@@ -42,6 +41,18 @@ public:
      */
     psyqo::Coroutine<> InitialLoad(void);
 };
+
+// Trap into the resident debugger with the exit code in $a0 via break
+// category 4. Categories 0/6/7/14 are taken (pcdrv / compiler overflow /
+// compiler divide-by-zero / psyqo), so 4 is free. On hardware this halts
+// the program (Unirom reports HLTD) and leaves the exit code readable in
+// $a0, giving the host a deterministic end-of-binary signal instead of a
+// printed sentinel string. On the emulator pcsx_exit() has already exited,
+// so this is never reached there.    
+static inline void exitBreak(int code) {
+    register int a0 asm("$4") = code;
+    __asm__ volatile("break 4, 0\n" : : "r"(a0) : "memory");
+}
 
 extern MadnightEngine g_madnightEngine;
 

--- a/src/mesh/colbin_manager.cpp
+++ b/src/mesh/colbin_manager.cpp
@@ -1,5 +1,5 @@
 #include "colbin_manager.hh"
-#include "../helpers/cdrom.hh"
+#include "../helpers/archive.hh"
 #include "psyqo/alloc.h"
 #include "psyqo/coroutine.hh"
 #include "psyqo/xprintf.h"
@@ -11,7 +11,7 @@ psyqo::Coroutine<> ColbinManager::LoadColbin(const eastl::fixed_string<char, MAX
     // just incase something goes wrong
     *colbinOut = nullptr;
 
-    auto buffer = co_await CDRomHelper::LoadFile(name.c_str());
+    auto buffer = co_await ArchiveHelper::LoadFile(name.c_str());
     void *data = buffer.data();
     size_t size = buffer.size();
 

--- a/src/mesh/mesh_manager.cpp
+++ b/src/mesh/mesh_manager.cpp
@@ -10,7 +10,7 @@
 
 LoadedMeshBin MeshManager::mLoadedMeshes[MAX_LOADED_MESHES];
 
-psyqo::Coroutine<> MeshManager::LoadMeshFromCDROM(const char *meshName, MeshBin **meshOut) {
+psyqo::Coroutine<> MeshManager::LoadMesh(const char *meshName, MeshBin **meshOut) {
   // make sure we get a valid response at least
   *meshOut = nullptr;
 

--- a/src/mesh/mesh_manager.cpp
+++ b/src/mesh/mesh_manager.cpp
@@ -1,6 +1,5 @@
 #include "mesh_manager.hh"
-#include "../helpers/cdrom.hh"
-#include "../helpers/world_space.hh"
+#include "../helpers/archive.hh"
 #include "psyqo/fixed-point.hh"
 #include "skeleton/skeleton.hh"
 
@@ -27,7 +26,7 @@ psyqo::Coroutine<> MeshManager::LoadMeshFromCDROM(const char *meshName, MeshBin 
   if (meshIx == -1)
     co_return;
 
-  auto buffer = co_await CDRomHelper::LoadFile(meshName);
+  auto buffer = co_await ArchiveHelper::LoadFile(meshName);
 
   void *data = buffer.data();
   size_t size = buffer.size();

--- a/src/mesh/mesh_manager.hh
+++ b/src/mesh/mesh_manager.hh
@@ -77,7 +77,7 @@ class MeshManager {
   static int8_t FindSpaceForMesh(void);
 
 public:
-  static psyqo::Coroutine<> LoadMeshFromCDROM(const char *meshName, MeshBin **meshOut);
+  static psyqo::Coroutine<> LoadMesh(const char *meshName, MeshBin **meshOut);
   static void GetMeshFromName(const char *meshName, MeshBin **meshOut);
   static void UnloadMesh(const char *mesh_name);
 

--- a/src/quaternion.cpp
+++ b/src/quaternion.cpp
@@ -95,7 +95,7 @@ Quaternion Slerp(const Quaternion &q1, const Quaternion &q2, psyqo::FixedPoint<>
   return slerpedQ;
 }
 
-Quaternion FindRotationQuat(const psyqo::Vec3 &v1, const psyqo::Vec3 &v2, psyqo::Trig<> &trig) {}
+Quaternion FindRotationQuat(const psyqo::Vec3 &v1, const psyqo::Vec3 &v2, psyqo::Trig<> &trig) { return {0,0,0,0}; }
 
 Quaternion operator*(const Quaternion &q1, const Quaternion &q2) {
   return Quaternion{

--- a/src/render/renderer.cpp
+++ b/src/render/renderer.cpp
@@ -148,7 +148,7 @@ void Renderer::SetFogNearFar(psyqo::FixedPoint<> near, psyqo::FixedPoint<> far) 
 
     // TODO: rewrite this to use fixed point numbers directly
     const auto dqa = ((-a * b / (b - a)) << 8) / h;
-    const auto dqaF = eastl::clamp<uint16_t>(dqa, -32767, 32767);
+    const auto dqaF = eastl::clamp<int16_t>(dqa, -32767, 32767);
     const auto dqbF = ((b << 12) / (b - a) << 12);
 
     psyqo::GTE::write<psyqo::GTE::Register::DQA, psyqo::GTE::Unsafe>(dqaF);

--- a/src/render/renderer.cpp
+++ b/src/render/renderer.cpp
@@ -148,7 +148,7 @@ void Renderer::SetFogNearFar(psyqo::FixedPoint<> near, psyqo::FixedPoint<> far) 
 
     // TODO: rewrite this to use fixed point numbers directly
     const auto dqa = ((-a * b / (b - a)) << 8) / h;
-    const auto dqaF = eastl::clamp(dqa, -32767, 32767);
+    const auto dqaF = eastl::clamp<uint16_t>(dqa, -32767, 32767);
     const auto dqbF = ((b << 12) / (b - a) << 12);
 
     psyqo::GTE::write<psyqo::GTE::Register::DQA, psyqo::GTE::Unsafe>(dqaF);

--- a/src/scenes/loading.cpp
+++ b/src/scenes/loading.cpp
@@ -41,6 +41,9 @@ psyqo::Coroutine<> LoadingScene::LoadFiles(eastl::vector<LoadQueue> &&files, boo
 	m_loadFilesCount = m_queue.size();
 	m_loadFilesLoadedCount = 0;
 
+	if (!m_queue.size())
+		co_return;
+
 	// load it backwards so we can erase as we go
 	// for (int i = m_queue.size() - 1; i >= 0; i--) {
 	for (auto const &file : m_queue) {

--- a/src/scenes/loading.cpp
+++ b/src/scenes/loading.cpp
@@ -50,24 +50,24 @@ psyqo::Coroutine<> LoadingScene::LoadFiles(eastl::vector<LoadQueue> &&files, boo
 		switch (file.type) {
 			case LoadFileType::OBJECT: {
 				MeshBin *mesh = nullptr;
-				co_await MeshManager::LoadMeshFromCDROM(file.name.c_str(), &mesh);
+				co_await MeshManager::LoadMesh(file.name.c_str(), &mesh);
 				break;
 			}
 
 			case LoadFileType::TEXTURE: {
 				TimFile *tim = nullptr;
-				co_await TextureManager::LoadTIMFromCDRom(file.name.c_str(), file.x, file.y, file.clutX, file.clutY, &tim);
+				co_await TextureManager::LoadTIM(file.name.c_str(), file.x, file.y, file.clutX, file.clutY, &tim);
 				break;
 			}
 
 			case LoadFileType::MOD_FILE: {
 				ModSoundFile *modSound = nullptr;
-				co_await ModSoundManager::LoadMODSoundFromCDRom(file.name.c_str(), &modSound);
+				co_await ModSoundManager::LoadMODSound(file.name.c_str(), &modSound);
 				break;
 			}
 
 			case LoadFileType::ANIMATION:
-				co_await AnimationManager::LoadAnimationFromCDRom(file.name.c_str());
+				co_await AnimationManager::LoadAnimation(file.name.c_str());
 				break;
 
 			case LoadFileType::COLBIN: {

--- a/src/sound/mod_sound_manager.cpp
+++ b/src/sound/mod_sound_manager.cpp
@@ -1,6 +1,6 @@
 #include "mod_sound_manager.hh"
 #include "psyqo/xprintf.h"
-#include "../helpers/cdrom.hh"
+#include "../helpers/archive.hh"
 #include "../render/renderer.hh"
 
 ModSoundFile ModSoundManager::m_currentSoundFile = {"", 0, false};
@@ -12,7 +12,7 @@ psyqo::Coroutine<> ModSoundManager::LoadMODSoundFromCDRom(const char *modSoundFi
     *modSoundFileOut = nullptr;
 
     // ok checks passed, get it off the CD
-    auto buffer = co_await CDRomHelper::LoadFile(modSoundFileName);
+    auto buffer = co_await ArchiveHelper::LoadFile(modSoundFileName);
     void *data = buffer.data();
     size_t size = buffer.size();
 

--- a/src/sound/mod_sound_manager.cpp
+++ b/src/sound/mod_sound_manager.cpp
@@ -7,7 +7,7 @@ ModSoundFile ModSoundManager::m_currentSoundFile = {"", 0, false};
 unsigned ModSoundManager::m_musicTimer = 0;
 uint16_t ModSoundManager::m_musicVolume = DEFAULT_MUSIC_VOLUME;
 
-psyqo::Coroutine<> ModSoundManager::LoadMODSoundFromCDRom(const char *modSoundFileName, ModSoundFile **modSoundFileOut)
+psyqo::Coroutine<> ModSoundManager::LoadMODSound(const char *modSoundFileName, ModSoundFile **modSoundFileOut)
 {
     *modSoundFileOut = nullptr;
 

--- a/src/sound/mod_sound_manager.hh
+++ b/src/sound/mod_sound_manager.hh
@@ -22,7 +22,7 @@ public:
     // as the SPU only contains 512K memory it is up to you to manage memory properly
     // this will give back some basic info about the loaded file incase you feel it is relevant
     // if it comes back as nullptr then something probably went wrong
-    static psyqo::Coroutine<> LoadMODSoundFromCDRom(const char *modSoundFileName, ModSoundFile **modSoundFileOut);
+    static psyqo::Coroutine<> LoadMODSound(const char *modSoundFileName, ModSoundFile **modSoundFileOut);
     // not really important but added for convenience
     static const ModSoundFile *CurrentMODSoundFile(void) { return &m_currentSoundFile; }
 

--- a/src/sound/sound_manager.cpp
+++ b/src/sound/sound_manager.cpp
@@ -1,5 +1,5 @@
 #include "sound_manager.hh"
-#include "../helpers/cdrom.hh"
+#include "../helpers/archive.hh"
 #include "EASTL/algorithm.h"
 #include "psyqo/spu.hh"
 #include "psyqo/fixed-point.hh"
@@ -33,7 +33,7 @@ psyqo::Coroutine<> SoundManager::LoadVAGFile(const eastl::fixed_string<char, MAX
     }
 
     // get the actual data off the cd and make sure its valid
-    auto buffer = co_await CDRomHelper::LoadFile(fileName.c_str());
+    auto buffer = co_await ArchiveHelper::LoadFile(fileName.c_str());
     void *data = buffer.data();
     size_t size = buffer.size();
 

--- a/src/textures/texture_manager.cpp
+++ b/src/textures/texture_manager.cpp
@@ -1,7 +1,7 @@
 #include "texture_manager.hh"
 #include "psyqo/alloc.h"
 #include "psyqo/xprintf.h"
-#include "../helpers/cdrom.hh"
+#include "../helpers/archive.hh"
 #include "../render/renderer.hh"
 
 /*
@@ -57,7 +57,7 @@ psyqo::Coroutine<> TextureManager::LoadTIMFromCDRom(const char *textureName, uin
     if (freeIx == -1)
         co_return;
 
-    auto buffer = co_await CDRomHelper::LoadFile(textureName);
+    auto buffer = co_await ArchiveHelper::LoadFile(textureName);
 
     void *data = buffer.data();
     size_t size = buffer.size();

--- a/src/textures/texture_manager.cpp
+++ b/src/textures/texture_manager.cpp
@@ -40,7 +40,7 @@
 
 eastl::array<TimFile, MAX_TEXTURES> TextureManager::m_textures;
 
-psyqo::Coroutine<> TextureManager::LoadTIMFromCDRom(const char *textureName, uint16_t x, uint16_t y, uint16_t clutX, uint16_t clutY, TimFile **timOut)
+psyqo::Coroutine<> TextureManager::LoadTIM(const char *textureName, uint16_t x, uint16_t y, uint16_t clutX, uint16_t clutY, TimFile **timOut)
 {
     *timOut = nullptr;
 

--- a/src/textures/texture_manager.hh
+++ b/src/textures/texture_manager.hh
@@ -33,7 +33,7 @@ class TextureManager final
     static TimFile *IsTextureLoaded(const char *name);
 
 public:
-    static psyqo::Coroutine<> LoadTIMFromCDRom(const char *textureName, uint16_t x, uint16_t y, uint16_t clutX, uint16_t clutY, TimFile **timOut);
+    static psyqo::Coroutine<> LoadTIM(const char *textureName, uint16_t x, uint16_t y, uint16_t clutX, uint16_t clutY, TimFile **timOut);
     static psyqo::PrimPieces::TPageAttr GetTPageAttr(const TimFile *tim);
     static psyqo::PrimPieces::TPageAttr GetTPageAttr(const TimFile &tim);
     static psyqo::Rect GetTPageUVForTim(const TimFile &tim);


### PR DESCRIPTION
Two major changes in this one:
1) Add the ability to use PCDRV when building using `-DPCDRV`
2) Moved away from traditional cd-rom ISOs in favour of psyqo's archive format. This means that any existing ISOs will need to be recreated using the [authoring tool](https://github.com/grumpycoders/pcsx-redux/tree/main/tools/authoring) that comes with pcsx-redux.